### PR TITLE
feat: Implement Open Control UI button (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # OpenClaw Dashboard Environment Variables
 API_URL=http://localhost:8000
+NEXT_PUBLIC_OPENCLAW_GATEWAY_URL=http://localhost:18789

--- a/components/openclaw/AgentSettingsTab.tsx
+++ b/components/openclaw/AgentSettingsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Plus, ExternalLink, Play, RotateCcw, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -16,10 +16,16 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import type { OpenClawAgent, UpdateAgentSettingsRequest, HeartbeatInterval } from '@/types/openclaw';
-import { MOCK_INTEGRATIONS, MOCK_API_KEY_PROVIDERS } from '@/lib/openclaw-mock-data';
+import type { OpenClawAgent, UpdateAgentSettingsRequest, HeartbeatInterval, Integration } from '@/types/openclaw';
+import type { AgentConfiguration } from '@/types/agent-configuration';
+import { MOCK_API_KEY_PROVIDERS } from '@/lib/openclaw-mock-data';
 import { MODEL_OPTIONS_RAW as MODEL_OPTIONS, HEARTBEAT_OPTIONS } from '@/lib/openclaw-utils';
 import IntegrationRow from './IntegrationRow';
+import GmailIntegrationModal from './GmailIntegrationModal';
+import LinkedInIntegrationModal from './LinkedInIntegrationModal';
+import DisconnectIntegrationDialog from './DisconnectIntegrationDialog';
+import openClawService from '@/lib/openclaw-service';
+import { useToast } from '@/hooks/use-toast';
 
 interface AgentSettingsTabProps {
   agent: OpenClawAgent;
@@ -235,16 +241,54 @@ export default function AgentSettingsTab({
         <div>
           <h3 className="text-sm font-semibold text-gray-900">Control</h3>
           <p className="text-sm text-gray-500 mt-0.5">
-            Access your agent&apos;s built-in management dashboard.
+            Access the OpenClaw Gateway dashboard to monitor all active sessions.
           </p>
         </div>
         <Button
           variant="outline"
           className="border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
+          disabled={
+            !agent.openclawSessionKey ||
+            !['running', 'paused'].includes(agent.status?.toLowerCase() || '')
+          }
+          onClick={() => {
+            const gatewayUrl = process.env.NEXT_PUBLIC_OPENCLAW_GATEWAY_URL || 'http://localhost:18789';
+
+            // Convert ws:// to http:// if needed
+            const httpUrl = gatewayUrl
+              .replace('ws://', 'http://')
+              .replace('wss://', 'https://');
+
+            // Check if URL is configured
+            if (!httpUrl || httpUrl === '') {
+              alert('OpenClaw Gateway URL not configured');
+              return;
+            }
+
+            // Open gateway root URL in new tab
+            window.open(httpUrl, '_blank', 'noopener,noreferrer');
+          }}
+          title={
+            !agent.openclawSessionKey
+              ? 'Agent must be provisioned first'
+              : !['running', 'paused'].includes(agent.status?.toLowerCase() || '')
+              ? 'Agent must be running or paused'
+              : 'Open OpenClaw Control UI in new window'
+          }
         >
           <ExternalLink className="h-4 w-4 mr-2" />
           Open Control UI
         </Button>
+        {!agent.openclawSessionKey && (
+          <p className="text-xs text-gray-400 italic">
+            Control UI will be available once the agent is provisioned.
+          </p>
+        )}
+        {agent.openclawSessionKey && !['running', 'paused'].includes(agent.status?.toLowerCase() || '') && (
+          <p className="text-xs text-gray-400 italic">
+            Control UI is only accessible when the agent is running or paused.
+          </p>
+        )}
       </div>
 
       <Separator className="bg-gray-100" />


### PR DESCRIPTION
## Summary

Implements functional "Open Control UI" button in Agent Settings tab (Issue #78).

## Changes

- Added `onClick` handler that opens OpenClaw Gateway dashboard
- Automatically converts `ws://` to `http://` URLs
- Button enabled only when:
  - Agent has `openclawSessionKey` (is provisioned)
  - Agent status is `running` or `paused`
- Added status-aware tooltips explaining disabled state
- Added helper text below button showing why it's disabled
- Updated description to clarify it opens gateway dashboard (not session-specific)
- Documented `NEXT_PUBLIC_OPENCLAW_GATEWAY_URL` in `.env.example`

## Technical Implementation

The button opens the gateway root URL (e.g., `http://localhost:18789/`) in a new tab. The OpenClaw Gateway provides a dashboard at the root URL that shows all active sessions - it's NOT session-specific.

**Button State Logic:**
```typescript
disabled={
  !agent.openclawSessionKey ||
  !['running', 'paused'].includes(agent.status?.toLowerCase() || '')
}
```

**URL Conversion:**
```typescript
const httpUrl = gatewayUrl
  .replace('ws://', 'http://')
  .replace('wss://', 'https://');
```

## Testing

### Manual Testing Steps:

1. Navigate to an agent detail page
2. Go to Settings tab
3. **Before provisioning:**
   - Button should be disabled
   - Tooltip: "Agent must be provisioned first"
   - Helper text: "Control UI will be available once the agent is provisioned."

4. **After provisioning (status: provisioning/stopped/failed):**
   - Button should be disabled
   - Tooltip: "Agent must be running or paused"
   - Helper text: "Control UI is only accessible when the agent is running or paused."

5. **After provisioning (status: running/paused):**
   - Button should be enabled
   - Tooltip: "Open OpenClaw Control UI in new window"
   - Clicking opens `http://localhost:18789/` in new tab
   - OpenClaw Gateway dashboard should load

### Environment Variables

The gateway URL defaults to `http://localhost:18789` but can be configured via:
```
NEXT_PUBLIC_OPENCLAW_GATEWAY_URL=http://localhost:18789
```

## Files Changed

- `components/openclaw/AgentSettingsTab.tsx` - Added button functionality
- `.env.example` - Documented gateway URL variable

## Related Issues

Closes #78

## Estimated Time

Implementation: 1 hour (as estimated in issue)